### PR TITLE
Give signer (Lambda's) permissions to the bucket and objects in the b…

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -8,9 +8,12 @@ provider:
       Action:
         - s3:*
       Resource:
-        Fn::GetAtt: 
-          - SignedUploadBucket
-          - Arn
+        - !GetAtt SignedUploadBucket.Arn
+        - Fn::Join:
+            - ""
+            - - "arn:aws:s3:::"
+              - Ref: "SignedUploadBucket"
+              - "/*"
   environment:
     BUCKET_NAME:
       Ref: SignedUploadBucket

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -8,7 +8,6 @@ provider:
       Action:
         - s3:*
       Resource:
-        - !GetAtt SignedUploadBucket.Arn
         - Fn::Join:
             - ""
             - - "arn:aws:s3:::"


### PR DESCRIPTION
*Current Behaviour*
Currently the signer has no access to objects within the bucket. The permissions of the signer determine the permissions of the user of the signed Url.
Because of that no new objects can be uploaded via the signed Url.

This results in a 403 `Forbidden` AccessDenied response.
![image](https://user-images.githubusercontent.com/36597466/79343057-37d2b380-7f2e-11ea-9d12-4a8ec5070cd3.png)

*Proposed updated Behaviour*
Give the signer (Lambda's) access to the object in the bucket.

This will result in a successful upload via the signed URL.
![image](https://user-images.githubusercontent.com/36597466/79343882-48cff480-7f2f-11ea-8f15-5e7486467a1c.png)

